### PR TITLE
Fix ambiguities in the output_bypass example

### DIFF
--- a/Task_level_Parallelism/Control_driven/Patterns/output_bypass/dut.cpp
+++ b/Task_level_Parallelism/Control_driven/Patterns/output_bypass/dut.cpp
@@ -16,16 +16,13 @@
  */
 
 void pass(int tmp1[128], int b[128]) {
-    int buff[127];
     for (int i = 0; i < 128; i++) {
         b[i] = tmp1[i];
     }
 }
 
 void split(int a[128], int tmp1[128], int tmp2[128]) {
-    static int j;
     for (int i = 0; i < 128; i++) {
-        j++;
         tmp1[i] = a[i];
         tmp2[i] = a[i];
     }

--- a/Task_level_Parallelism/Control_driven/Patterns/output_bypass/dut_sol.cpp
+++ b/Task_level_Parallelism/Control_driven/Patterns/output_bypass/dut_sol.cpp
@@ -23,9 +23,7 @@ void pass(int tmp3[128], int tmp2[128], int tmp1[128], int b[128]) {
 }
 
 void split(int a[128], int tmp1[128], int tmp2[128]) {
-    static int j;
     for (int i = 0; i < 128; i++) {
-        j++;
         tmp1[i] = a[i];
         tmp2[i] = a[i];
     }

--- a/Task_level_Parallelism/Control_driven/Patterns/output_bypass/test_dut.cpp
+++ b/Task_level_Parallelism/Control_driven/Patterns/output_bypass/test_dut.cpp
@@ -36,8 +36,8 @@ int main() {
 
     for (int j = 0; j < 512; j++) {
         if (b[j] != (a[j]) || tmp[j] != a[j]) {
-            std::cout << "value of i is" << j << "value of a[j] is" << a[j]
-                      << "value of out b[j] is " << b[j]
+            std::cout << "value of j is" << j << "value of a[j] is" << a[j]
+                      << "value of b[j] is " << b[j]
                       << "value of tmp[j] is " << tmp[j] << std::endl;
             return 1;
             break;


### PR DESCRIPTION
An unused buffer and counters have been deleted. Typos with the index and the signal name in the debugging message have been fixed.