### PR TITLE
Fix ambiguities in the Patterns/*_bypass examples

### DIFF
--- a/Task_level_Parallelism/Control_driven/Patterns/input_bypass/dut.cpp
+++ b/Task_level_Parallelism/Control_driven/Patterns/input_bypass/dut.cpp
@@ -17,7 +17,6 @@
 
 void add_kernel(int tmp1[128], int tmp2[128], int tmp3[128]) {
 
-    int buff[127];
     for (int i = 0; i < 128; i++) {
         tmp3[i] = tmp1[i] + tmp2[i];
     }
@@ -25,7 +24,6 @@ void add_kernel(int tmp1[128], int tmp2[128], int tmp3[128]) {
 
 void double_pass(int b[128], int tmp2[128], int tmp1[128], int tmp4[128]) {
 
-    int buff[127];
     for (int i = 0; i < 128; i++) {
         tmp2[i] = b[i];
         tmp4[i] = tmp1[i];
@@ -33,6 +31,7 @@ void double_pass(int b[128], int tmp2[128], int tmp1[128], int tmp4[128]) {
 }
 
 void pass(int a[128], int tmp1[128]) {
+
     for (int i = 0; i < 128; i++) {
         tmp1[i] = a[i];
     }

--- a/Task_level_Parallelism/Control_driven/Patterns/input_bypass/dut_sol.cpp
+++ b/Task_level_Parallelism/Control_driven/Patterns/input_bypass/dut_sol.cpp
@@ -17,7 +17,6 @@
 
 void add_kernel(int tmp1[128], int tmp2[128], int tmp3[128]) {
 
-    int buff[127];
     for (int i = 0; i < 128; i++) {
         tmp3[i] = tmp1[i] + tmp2[i];
     }
@@ -25,7 +24,6 @@ void add_kernel(int tmp1[128], int tmp2[128], int tmp3[128]) {
 
 void Double_pass(int tmp2[128], int tmp1[128], int tmp4[128], int tmp5[128]) {
 
-    int buff[127];
     for (int i = 0; i < 128; i++) {
         tmp4[i] = tmp1[i];
         tmp5[i] = tmp2[i];
@@ -33,6 +31,7 @@ void Double_pass(int tmp2[128], int tmp1[128], int tmp4[128], int tmp5[128]) {
 }
 
 void pass(int a[128], int b[128], int tmp1[128], int tmp2[128]) {
+
     for (int i = 0; i < 128; i++) {
         tmp1[i] = a[i];
         tmp2[i] = b[i];

--- a/Task_level_Parallelism/Control_driven/Patterns/input_bypass/test_dut.cpp
+++ b/Task_level_Parallelism/Control_driven/Patterns/input_bypass/test_dut.cpp
@@ -40,8 +40,8 @@ int main() {
 
     for (int j = 0; j < 512; j++) {
         if (tmp[j] != 2 * j) {
-            std::cout << "value of i is" << j << "value of a[j] is" << a[j]
-                      << "value of out b[j] is " << b[j]
+            std::cout << "value of j is" << j << "value of a[j] is" << a[j]
+                      << "value of b[j] is " << b[j]
                       << "value of tmp[j] is " << tmp[j] << std::endl;
             return 1;
             break;

--- a/Task_level_Parallelism/Control_driven/Patterns/middle_bypass/dut.cpp
+++ b/Task_level_Parallelism/Control_driven/Patterns/middle_bypass/dut.cpp
@@ -16,28 +16,22 @@
  */
 
 void bypass(int tmp1[128], int tmp2[128], int tmp3[128]) {
-    //	static int j;
 
-    int buff[127];
     for (int i = 0; i < 128; i++) {
         tmp3[i] = tmp1[i] + tmp2[i];
     }
 }
 
 void pass(int tmp2[128], int tmp4[128]) {
-    //	static int j;
 
-    int buff[127];
     for (int i = 0; i < 128; i++) {
-
         tmp4[i] = tmp2[i];
     }
 }
 
 void double_pass(int a[128], int b[128], int tmp1[128], int tmp2[128]) {
-    static int j;
+
     for (int i = 0; i < 128; i++) {
-        j++;
         tmp1[i] = a[i];
         tmp2[i] = b[i];
     }

--- a/Task_level_Parallelism/Control_driven/Patterns/middle_bypass/dut_sol.cpp
+++ b/Task_level_Parallelism/Control_driven/Patterns/middle_bypass/dut_sol.cpp
@@ -23,20 +23,16 @@ void bypass(int tmp1[128], int tmp2[128], int tmp3[128]) {
 }
 
 void pass(int tmp2[128], int tmp4[128], int tmp1[128], int tmp5[128]) {
-    //	static int j;
 
-    int buff[127];
     for (int i = 0; i < 128; i++) {
-
         tmp4[i] = tmp2[i];
         tmp5[i] = tmp1[i];
     }
 }
 
 void double_pass(int a[128], int b[128], int tmp1[128], int tmp2[128]) {
-    static int j;
+
     for (int i = 0; i < 128; i++) {
-        j++;
         tmp1[i] = a[i];
         tmp2[i] = b[i];
     }

--- a/Task_level_Parallelism/Control_driven/Patterns/middle_bypass/test_dut.cpp
+++ b/Task_level_Parallelism/Control_driven/Patterns/middle_bypass/test_dut.cpp
@@ -40,8 +40,8 @@ int main() {
 
     for (int j = 0; j < 512; j++) {
         if (tmp[j] != a[j] + b[j]) {
-            std::cout << "value of i is" << j << "value of a[j] is" << a[j]
-                      << "value of out b[j] is " << b[j]
+            std::cout << "value of j is" << j << "value of a[j] is" << a[j]
+                      << "value of b[j] is " << b[j]
                       << "value of tmp[j] is " << tmp[j] << std::endl;
             return 1;
             break;

--- a/Task_level_Parallelism/Control_driven/Patterns/output_bypass/dut.cpp
+++ b/Task_level_Parallelism/Control_driven/Patterns/output_bypass/dut.cpp
@@ -16,16 +16,15 @@
  */
 
 void pass(int tmp1[128], int b[128]) {
-    int buff[127];
+
     for (int i = 0; i < 128; i++) {
         b[i] = tmp1[i];
     }
 }
 
 void split(int a[128], int tmp1[128], int tmp2[128]) {
-    static int j;
+
     for (int i = 0; i < 128; i++) {
-        j++;
         tmp1[i] = a[i];
         tmp2[i] = a[i];
     }

--- a/Task_level_Parallelism/Control_driven/Patterns/output_bypass/dut_sol.cpp
+++ b/Task_level_Parallelism/Control_driven/Patterns/output_bypass/dut_sol.cpp
@@ -16,6 +16,7 @@
  */
 
 void pass(int tmp3[128], int tmp2[128], int tmp1[128], int b[128]) {
+
     for (int i = 0; i < 128; i++) {
         b[i] = tmp1[i];
         tmp2[i] = tmp3[i];
@@ -23,9 +24,8 @@ void pass(int tmp3[128], int tmp2[128], int tmp1[128], int b[128]) {
 }
 
 void split(int a[128], int tmp1[128], int tmp2[128]) {
-    static int j;
+
     for (int i = 0; i < 128; i++) {
-        j++;
         tmp1[i] = a[i];
         tmp2[i] = a[i];
     }

--- a/Task_level_Parallelism/Control_driven/Patterns/output_bypass/test_dut.cpp
+++ b/Task_level_Parallelism/Control_driven/Patterns/output_bypass/test_dut.cpp
@@ -36,8 +36,8 @@ int main() {
 
     for (int j = 0; j < 512; j++) {
         if (b[j] != (a[j]) || tmp[j] != a[j]) {
-            std::cout << "value of i is" << j << "value of a[j] is" << a[j]
-                      << "value of out b[j] is " << b[j]
+            std::cout << "value of j is" << j << "value of a[j] is" << a[j]
+                      << "value of b[j] is " << b[j]
                       << "value of tmp[j] is " << tmp[j] << std::endl;
             return 1;
             break;


### PR DESCRIPTION
Unused local buffers and counters have been deleted. Typos with the index and the port name in the debugging message have been fixed.